### PR TITLE
added shebangs and made .py files runnable

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import multiprocessing as mp
 from multiprocessing.pool import ThreadPool
 import subprocess as sp

--- a/pycompiler_old.py
+++ b/pycompiler_old.py
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env python3
 import time
 import ast
 


### PR DESCRIPTION
This pull requests enables the easy execution of the scripts with just
```bash
./compile.py
```
instead of the more cumbersome
```bash
python3 compile.py
```